### PR TITLE
Update test oracles after mesh-boolean seam-closure fixes (June 2026)

### DIFF
--- a/models/MeshBooleanUnion/lands_terrain_path_spline_step1.3dm
+++ b/models/MeshBooleanUnion/lands_terrain_path_spline_step1.3dm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d2cf7dd91c9c28a200124d165bd55220358c56c5403ab55a1947c20a53f3adab
-size 459175
+oid sha256:ad1d6dda6cb6bb78a51fc8e7eb3de266e7c90e1c33f6aa33cb7a3c69a29dceb8
+size 459431

--- a/models/MeshSplit/discourse-impossible-to-split-mesh.3dm
+++ b/models/MeshSplit/discourse-impossible-to-split-mesh.3dm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8cbffd878cdc654805d5d762f7ea0d2868670fe0a509ae78c1554466855bd512
-size 80793
+oid sha256:1f1eb74ad153722939f0f8f20a1b3d0a0b570b44cd52c501feff8930aa55214d
+size 158429


### PR DESCRIPTION
lands_terrain_path_spline_step1: union now closes cleanly (new area).
discourse-impossible-to-split-mesh: accepted new split result after inspection.